### PR TITLE
Add SplitResult.getauthority()

### DIFF
--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -228,6 +228,20 @@ class SplitTest(unittest.TestCase):
             self.assertEqual(result.gethost(), 'bar')
             self.assertEqual(result.getport(8000), 8000)
 
+    def test_getauthority(self):
+        """test appending path components"""
+        cases = [
+            ('http://john:doe@Test.python.org/foo/',
+             ('john:doe', 'Test.python.org', None)),
+            ('http://john:doe@Test.python.org:8080/foo/',
+             ('john:doe', 'Test.python.org', '8080')),
+            ('foo://username:password@www.example.com:1234?name=ferret',
+             ('username:password', 'www.example.com', '1234'))
+        ]
+
+        for uri, result in cases:
+            self.assertEquals(urisplit(uri).getauthority(), result)
+
     def test_getpath(self):
         cases = [
             ('', '', '/'),

--- a/uritools/split.py
+++ b/uritools/split.py
@@ -148,6 +148,23 @@ class SplitResult(collections.namedtuple('SplitResult', _URI_COMPONENTS)):
         else:
             return default
 
+    def getauthority(self, encoding='utf-8', errors='strict', default=None):
+        """Return the normalized decoded URI path."""
+        if self.userinfo:
+            info = uridecode(self.userinfo, encoding, errors)
+        else:
+            info = default
+        if self.host:
+            host = uridecode(self.host, encoding, errors)
+        else:
+            host = default
+        if self.port:
+            port = uridecode(self.port, encoding, errors)
+        else:
+            port = default
+        return (info, host, port)
+
+
     def getpath(self, encoding='utf-8', errors='strict'):
         """Return the normalized decoded URI path."""
         path = self.__remove_dot_segments(self.path)


### PR DESCRIPTION
This adds getauthority method to SplitResult class and a couple simple test cases.

https://github.com/tkem/uritools/issues/51