### PR TITLE
Test with newer Python versions, abandon EOLed ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ language: python
 
 python:
 - 2.7
-- 3.4
 - 3.5
 - 3.6
+- 3.7
+- 3.8-dev
 
 install:
 - pip install coveralls tox

--- a/setup.py
+++ b/setup.py
@@ -44,10 +44,10 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Internet',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]


### PR DESCRIPTION
Working on a Python 3.8 migration where this is a dependency. It would be great to have a release that has been tested against 3.8.

Also took the opportunity to clear old python versions that are no longer supported.

Thanks for taking a look.