### PR TITLE
Add power support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,15 @@ python:
 - 3.8
 - pypy3
 
+arch: 
+- amd64
+- ppc64le
+
+jobs:
+  exclude:
+     - arch: ppc64le
+       python: pypy3
+
 install:
 - pip install coveralls tox
 


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.