### PR TITLE
fix: treat uricompose path=None as empty path

### DIFF
--- a/src/uritools/__init__.py
+++ b/src/uritools/__init__.py
@@ -773,6 +773,8 @@ def uricompose(
     # path component must either be empty or begin with a slash ("/")
     # character.  If a URI does not contain an authority component,
     # then the path cannot begin with two slash characters ("//").
+    if path is None:
+        path = ""
     path = uriencode(path, _SAFE_PATH, encoding)
     if authority is not None and path and not path.startswith(b"/"):
         raise ValueError("Invalid path with authority component")

--- a/src/uritools/__init__.pyi
+++ b/src/uritools/__init__.pyi
@@ -232,7 +232,7 @@ def uricompose(
     | bytes
     | Sequence[str | bytes | ipaddress.IPv4Address | ipaddress.IPv6Address | int | None]
     | None = ...,
-    path: str | bytes = ...,
+    path: str | bytes | None = ...,
     query: _QueryType | None = ...,
     fragment: str | bytes | None = ...,
     userinfo: str | bytes | None = ...,

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -180,6 +180,10 @@ class ComposeTest(unittest.TestCase):
             with self.assertRaises(ValueError, msg="path=%r" % path):
                 uricompose(path=path)
 
+        # None path matches the empty-path default
+        self.check("https://ex.com", scheme="https", host="ex.com", path=None)
+        self.check("https://ex.com/", scheme="https", host="ex.com", path="/")
+
     def test_query(self):
         from collections import OrderedDict as od
 


### PR DESCRIPTION
uricompose hits AttributeError when path=None. This PR fixes the regression with a focused test covering the case.