### PR TITLE
fix: keep all-digit hosts when no port separator is present

### DIFF
--- a/src/uritools/__init__.py
+++ b/src/uritools/__init__.py
@@ -158,11 +158,12 @@ class SplitResult(
         if authority is None:
             return None
         _, _, hostinfo = authority.rpartition(self._AT)
-        host, _, port = hostinfo.rpartition(self._COLON)
-        if port.lstrip(self._DIGITS):
-            return hostinfo
-        else:
+        # Without a ":", rpartition puts the whole hostinfo in the port slot.
+        host, present, port = hostinfo.rpartition(self._COLON)
+        if present and not port.lstrip(self._DIGITS):
             return host
+        else:
+            return hostinfo
 
     @property
     def port(self):

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -311,6 +311,33 @@ class SplitTest(unittest.TestCase):
             with self.assertRaises(ValueError, msg="%r" % uri):
                 urisplit(uri.encode()).gethost()
 
+    def test_all_digit_host_without_port(self):
+        cases = [
+            ("http://123", "123", None, (None, "123", None)),
+            ("http://0", "0", None, (None, "0", None)),
+            ("http://2130706433", "2130706433", None, (None, "2130706433", None)),
+            ("http://0123", "0123", None, (None, "0123", None)),
+            ("http://user@123", "123", None, ("user", "123", None)),
+            ("http://123:80", "123", 80, (None, "123", 80)),
+            ("http://user@123:80", "123", 80, ("user", "123", 80)),
+            ("//123/path", "123", None, (None, "123", None)),
+            ("http://123/", "123", None, (None, "123", None)),
+            ("http://123?q", "123", None, (None, "123", None)),
+            ("http://123#f", "123", None, (None, "123", None)),
+            ("http://123:", "123", None, (None, "123", None)),
+            ("http://example.com", "example.com", None, (None, "example.com", None)),
+            ("http://", "", None, (None, "", None)),
+        ]
+        for uri, host, port, authority in cases:
+            for ref in (uri, uri.encode("ascii")):
+                parts = urisplit(ref)
+                self.assertEqual(
+                    parts.host, host if isinstance(ref, str) else host.encode()
+                )
+                self.assertEqual(parts.gethost(), host)
+                self.assertEqual(parts.getport(), port)
+                self.assertEqual(parts.getauthority(), authority)
+
     def test_getport(self):
         for uri in ["foo://bar", "foo://bar:", "foo://bar/", "foo://bar:/"]:
             result = urisplit(uri)


### PR DESCRIPTION
SplitResult.host hits data-loss when all-digit host without port returns empty. This PR fixes the regression with a focused test covering the case.